### PR TITLE
Fix benchmark

### DIFF
--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -410,7 +410,7 @@ pub fn run_benchmark(c: &mut Criterion) {
 
 }
 
-pub fn do_a_benchmark(c: &mut Criterion,mut algorithm: impl FDTableTestable, algoname:&str) {
+pub fn do_a_benchmark(c: &mut Criterion,mut algorithm: impl FDTableTestable + 'static, algoname:&str) {
 
     let mut group = c.benchmark_group("primitives basics");
     // Set it up...
@@ -471,19 +471,18 @@ pub fn do_a_benchmark(c: &mut Criterion,mut algorithm: impl FDTableTestable, alg
     let _fd3 = algorithm.get_unused_virtual_fd(threei::TESTING_CAGEID, 30, true, 300).unwrap();
 
     let mut thread_handle_vec:Vec<thread::JoinHandle<()>> = Vec::new();
+    let algwrapper = Arc::new(algorithm);
 
-
-    group.bench_function(format!("{}: translate_virtual_fd (10000)",algoname),
-            |b| b.iter({
-                let algwrapper = Arc::new(algorithm);
+    group.bench_function(format!("{}: translate_virtual_fd (10000)",algoname), |b| b.iter({ 
+        || {
                 let newalgorithm  = Arc::clone(&algwrapper);
-                move|| { 
                 thread_handle_vec.push(thread::spawn(move || {
                     for _ in [0..1000].iter() {
                         newalgorithm.translate_virtual_fd(threei::TESTING_CAGEID, fd).unwrap();
                     }
                 }));
-            }})
+            }}
+        )
         );
 
     for handle in thread_handle_vec {

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -417,7 +417,7 @@ pub fn do_a_benchmark(c: &mut Criterion,mut algorithm: impl FDTableTestable + 's
     algorithm.refresh();
 
     let fd = algorithm.get_unused_virtual_fd(threei::TESTING_CAGEID, 10, true, 100).unwrap();
-    group.bench_function(format!("{}: translate_virtual_fd (10000)",algoname),
+    group.bench_function(format!("{}: [single-threaded] translate_virtual_fd (10000)",algoname),
             |b| b.iter(|| {
                 for _ in [0..1000].iter() {
                     algorithm.translate_virtual_fd(threei::TESTING_CAGEID, fd).unwrap();
@@ -473,7 +473,7 @@ pub fn do_a_benchmark(c: &mut Criterion,mut algorithm: impl FDTableTestable + 's
     let mut thread_handle_vec:Vec<thread::JoinHandle<()>> = Vec::new();
     let algwrapper = Arc::new(algorithm);
 
-    group.bench_function(format!("{}: translate_virtual_fd (10000)",algoname), |b| b.iter({ 
+    group.bench_function(format!("{}: [multi-threaded] translate_virtual_fd (10000)",algoname), |b| b.iter({ 
         || {
                 let newalgorithm  = Arc::clone(&algwrapper);
                 thread_handle_vec.push(thread::spawn(move || {


### PR DESCRIPTION
- Using `Arc` and `Send` + `Sync` on traits and structs was the way to go. 

The issue was with an unnecessary closure added [here](https://github.com/JustinCappos/fdtables/blob/a06f0e6210afc1db10ac1a6c8048f9e3c1aea014/benches/primitives.rs#L480).

Also had to add 'static lifetime to the function param. The lifetime issue only happens when threads take ownership of data, so have to add a lifetime annotation. There might be a better way of convey the intent that the `algorithm` lives for the entirety of the function, I don't know.