### PR TITLE
Fix: updating DashmapArr fdtable when close

### DIFF
--- a/src/dashmaparrayglobal.rs
+++ b/src/dashmaparrayglobal.rs
@@ -359,6 +359,7 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
         // Zero out this entry before calling the close handler...
         myfdrow[virtfd as usize] = None;
 
+        // Re-insert the modified myfdrow since I've been modifying a copy
         FDTABLE.insert(cageid, myfdrow.clone());
         
         // always _decrement last as it may call the user handler...

--- a/src/dashmaparrayglobal.rs
+++ b/src/dashmaparrayglobal.rs
@@ -359,6 +359,8 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
         // Zero out this entry before calling the close handler...
         myfdrow[virtfd as usize] = None;
 
+        FDTABLE.insert(cageid, myfdrow.clone());
+        
         // always _decrement last as it may call the user handler...
         _decrement_fdcount(entry.unwrap());
         return Ok(());

--- a/src/dashmapvecglobal.rs
+++ b/src/dashmapvecglobal.rs
@@ -358,6 +358,8 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
         // Zero out this entry before calling the close handler...
         myfdrow[virtfd as usize] = None;
 
+        FDTABLE.insert(cageid, myfdrow.clone());
+        
         // always _decrement last as it may call the user handler...
         _decrement_fdcount(entry.unwrap());
         return Ok(());

--- a/src/dashmapvecglobal.rs
+++ b/src/dashmapvecglobal.rs
@@ -358,6 +358,7 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
         // Zero out this entry before calling the close handler...
         myfdrow[virtfd as usize] = None;
 
+        // Re-insert the modified myfdrow since I've been modifying a copy
         FDTABLE.insert(cageid, myfdrow.clone());
         
         // always _decrement last as it may call the user handler...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1453,4 +1453,30 @@ mod tests {
         // should panic here...
         close_virtualfd(threei::TESTING_CAGEID, fd1).unwrap();
     }
+
+    #[test]
+    // To check if item has been removed successfully after close
+    fn test_close_fdtable_update() {
+        let mut _thelock = TESTMUTEX.lock().unwrap_or_else(|e| {
+            refresh();
+            TESTMUTEX.clear_poison();
+            e.into_inner()
+        });
+        refresh();
+
+        const FDKIND: u32 = 0;
+        const UNDERFD: u64 = 10;
+        // Acquire a virtual fd...
+        let my_virt_fd =
+            get_unused_virtual_fd(threei::TESTING_CAGEID, FDKIND, UNDERFD, false, 100).unwrap();
+        
+        close_virtualfd(threei::TESTING_CAGEID, my_virt_fd).unwrap();
+
+        // translate_virtual_fd should return error, because there should have 
+        // no requested my_virt_fd after close
+        match translate_virtual_fd(threei::TESTING_CAGEID, my_virt_fd) {
+            Ok(_) => panic!("translate_virtual_fd should return error!!"),
+            Err(_e) => {TESTMUTEX.clear_poison();}
+        }
+    }
 }


### PR DESCRIPTION
## Issue
When testing with the RustPOSIX test suite, RawPOSIX panicked in several tests. The root cause was identified as the FDTable (implemented using `DashmapArray`) not being updated after the `close_syscall`. This issue arose from modifying a local copy (`myfdrow`) without updating the actual FDTable.

## Reason
`myfdrow` was a mutable copy of the row of file descriptors associated with a given cageid. After setting an entry to None, the change wasn't reflected in the actual FDTable because only the local copy was modified.

## Fix
After modifying `myfdrow`, the function needs to update FDTABLE to reflect this change. The line `FDTABLE.insert(cageid, myfdrow.clone());` performs this update by inserting the modified `myfdrow` back into FDTABLE. The `.clone()` method is used to ensure that a new copy of `myfdrow` is inserted, as FDTABLE likely requires ownership of the value being inserted.

## Test
Passed all inner FDtables' tests with `cargo test`