### PR TITLE
Add fd limit check to prevent exceeding max allowed value

### DIFF
--- a/src/dashmaparrayglobal.rs
+++ b/src/dashmaparrayglobal.rs
@@ -84,6 +84,12 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
     // time
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
 
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtualfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+
     return match FDTABLE.get(&cageid).unwrap()[virtualfd as usize] {
         Some(tableentry) => Ok(tableentry),
         None => Err(threei::Errno::EBADFD as u64),

--- a/src/dashmapvecglobal.rs
+++ b/src/dashmapvecglobal.rs
@@ -363,8 +363,9 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
         // Zero out this entry before calling the close handler...
         myfdrow[virtfd as usize] = None;
 
+        // Re-insert the modified myfdrow since I've been modifying a copy
         FDTABLE.insert(cageid, myfdrow.clone());
-
+        
         // always _decrement last as it may call the user handler...
         _decrement_fdcount(entry.unwrap());
         return Ok(());

--- a/src/dashmapvecglobal.rs
+++ b/src/dashmapvecglobal.rs
@@ -43,7 +43,7 @@ pub const ALGONAME: &str = "DashMapVecGlobal";
 lazy_static! {
 
     #[derive(Debug)]
-    pub static ref FDTABLE: DashMap<u64, Vec<Option<FDTableEntry>>> = {
+    static ref FDTABLE: DashMap<u64, Vec<Option<FDTableEntry>>> = {
         let m = DashMap::new();
         // Insert a cage so that I have something to fork / test later, if need
         // be. Otherwise, I'm not sure how I get this started. I think this

--- a/src/muthashmaxglobal.rs
+++ b/src/muthashmaxglobal.rs
@@ -133,6 +133,12 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
         panic!("Unknown cageid in fdtable access");
     }
 
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtualfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+    
     return match fdtable.get(&cageid).unwrap().thisfdtable.get(&virtualfd) {
         Some(tableentry) => Ok(tableentry.realfd),
         None => Err(threei::Errno::EBADFD as u64),

--- a/src/vanillaglobal.rs
+++ b/src/vanillaglobal.rs
@@ -115,6 +115,12 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
         panic!("Unknown cageid in fdtable access");
     }
 
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtualfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+
     return match fdtable.get(&cageid).unwrap().get(&virtualfd) {
         Some(tableentry) => Ok(tableentry.realfd),
         None => Err(threei::Errno::EBADFD as u64),


### PR DESCRIPTION
I met one edge case while refactoring the new codebase, and this issue has been fixed in old rawposix codebase. 

I added a check to ensure that if the requested fd exceeds the predefined limit (1024), an error is returned instead of causing a potential panic in the future. Raise a PR to ensure consistency between different versions, keeping behavior aligned across the codebase.

Added test case in this situation and updated version passed test suite.